### PR TITLE
fix: resolve 'projects.map is not a function' error in JIRA projects API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced performance optimizations
 - Advanced JIRA automation workflows
 
+## [0.5.1] - 2025-06-05
+
+### 🐛 Critical Bug Fixes
+
+- **🚨 JIRA Projects API Pagination Fixed**: Resolved `projects.map is not a function` error
+  - **Issue**: JIRA `/project/search` API returns paginated responses with `{values: [...]}` structure
+  - **Error**: Code expected direct arrays, causing `projects.map is not a function` when using `jira_get_projects`
+  - **Fix**: Updated ProjectRepository to properly extract `values` array from paginated responses
+  - **Impact**: Users can now successfully use `jira_get_projects` and `jira_get_projects searchQuery="..."` commands
+  - **Location**: `src/features/jira/projects/repositories/project.repository.ts`
+
+### 🔧 Technical Details
+
+- **Root Cause**: JIRA API pagination structure mismatch in projects repository
+- **Solution**: Added `PaginatedResponse<T>` and `ProjectSearchResponse` interfaces with proper value extraction
+- **Validation**: All 829 tests passing with comprehensive coverage across all domains
+- **Testing**: Enhanced mock factories and repository test coverage
+- **Compatibility**: Fully backward compatible with no breaking changes
+
+### 📋 Release Process
+
+- **Type**: Patch release (0.5.0 → 0.5.1)
+- **Priority**: High - resolves user-blocking issues
+- **Compatibility**: Fully backward compatible
+- **Dependencies**: No dependency changes required
+
 ## [0.5.0] - 2025-06-05
 
 ### 🆕 New Tools

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsazz/mcp-jira",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A powerful Model Context Protocol (MCP) server for Atlassian JIRA integration. Access JIRA projects, manage issues, and streamline development workflows directly from any MCP-compatible editor or application.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/features/jira/projects/models/project.models.ts
+++ b/src/features/jira/projects/models/project.models.ts
@@ -20,6 +20,24 @@ export interface GetProjectsOptions {
 }
 
 /**
+ * Generic paginated response structure from JIRA API
+ */
+export interface PaginatedResponse<T> {
+  self: string;
+  nextPage?: string;
+  maxResults: number;
+  startAt: number;
+  total: number;
+  isLast: boolean;
+  values: T[];
+}
+
+/**
+ * Project search response from JIRA API
+ */
+export interface ProjectSearchResponse extends PaginatedResponse<Project> {}
+
+/**
  * Project types for the JIRA projects domain
  */
 

--- a/src/features/jira/projects/repositories/project.repository.ts
+++ b/src/features/jira/projects/repositories/project.repository.ts
@@ -4,6 +4,7 @@ import type {
   GetProjectsOptions,
   Project,
   ProjectPermissions,
+  ProjectSearchResponse,
 } from "../models";
 
 /**
@@ -70,11 +71,15 @@ export class ProjectRepositoryImpl implements ProjectRepository {
       queryParams.orderBy = options.orderBy;
     }
 
-    return this.httpClient.sendRequest<Project[]>({
+    // Get paginated response from JIRA API
+    const response = await this.httpClient.sendRequest<ProjectSearchResponse>({
       endpoint: "project/search",
       method: "GET",
       queryParams,
     });
+
+    // Extract and return the projects array from the paginated response
+    return response.values;
   }
 
   /**
@@ -128,10 +133,14 @@ export class ProjectRepositoryImpl implements ProjectRepository {
       maxResults,
     };
 
-    return this.httpClient.sendRequest<Project[]>({
+    // Get paginated response from JIRA API
+    const response = await this.httpClient.sendRequest<ProjectSearchResponse>({
       endpoint: "project/search",
       method: "GET",
       queryParams,
     });
+
+    // Extract and return the projects array from the paginated response
+    return response.values;
   }
 }

--- a/src/test/mocks/projects/project-mock-factory.ts
+++ b/src/test/mocks/projects/project-mock-factory.ts
@@ -6,6 +6,7 @@ import type {
   GetProjectsOptions,
   Project,
   ProjectPermissions,
+  ProjectSearchResponse,
 } from "@features/jira/projects/models";
 import type { ProjectRepository } from "@features/jira/projects/repositories";
 
@@ -62,4 +63,36 @@ export function createMockProjectList(count = 3): Project[] {
       style: "next-gen",
       isPrivate: false,
     }));
+}
+
+/**
+ * Creates a mock paginated project search response
+ */
+export function createMockProjectSearchResponse(
+  projects: Project[] = createMockProjectList(),
+  options: {
+    startAt?: number;
+    maxResults?: number;
+    total?: number;
+    isLast?: boolean;
+  } = {},
+): ProjectSearchResponse {
+  const {
+    startAt = 0,
+    maxResults = 50,
+    total = projects.length,
+    isLast = true,
+  } = options;
+
+  return {
+    self: "https://test.atlassian.net/rest/api/3/project/search",
+    nextPage: isLast
+      ? undefined
+      : `https://test.atlassian.net/rest/api/3/project/search?startAt=${startAt + maxResults}`,
+    maxResults,
+    startAt,
+    total,
+    isLast,
+    values: projects,
+  };
 }

--- a/src/test/unit/features/jira/projects/repositories/project.repository.test.ts
+++ b/src/test/unit/features/jira/projects/repositories/project.repository.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Project Repository Unit Tests
+ * Tests for JIRA project repository with paginated response handling
+ */
+
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import type {
+  HttpClient,
+  HttpRequestOptions,
+} from "@features/jira/client/http/jira.http.types";
+import type { ProjectSearchResponse } from "@features/jira/projects/models";
+import { ProjectRepositoryImpl } from "@features/jira/projects/repositories/project.repository";
+import {
+  createMockProject,
+  createMockProjectSearchResponse,
+} from "@test/mocks/projects/project-mock-factory";
+import { setupTests } from "@test/utils/test-setup";
+
+// Setup test environment
+setupTests();
+
+describe("ProjectRepositoryImpl", () => {
+  let repository: ProjectRepositoryImpl;
+  let mockHttpClient: HttpClient;
+
+  beforeEach(() => {
+    mockHttpClient = {
+      sendRequest: mock() as Mock<
+        (options: HttpRequestOptions) => Promise<ProjectSearchResponse>
+      >,
+      getBaseUrl: mock(() => "https://test.atlassian.net"),
+    } as HttpClient;
+
+    repository = new ProjectRepositoryImpl(mockHttpClient);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe("getProjects", () => {
+    test("should extract projects from paginated response", async () => {
+      const mockProjects = [
+        createMockProject({ key: "PROJ1", name: "Project 1" }),
+        createMockProject({ key: "PROJ2", name: "Project 2" }),
+      ];
+
+      const mockResponse = createMockProjectSearchResponse(mockProjects);
+
+      (
+        mockHttpClient.sendRequest as Mock<
+          (options: HttpRequestOptions) => Promise<ProjectSearchResponse>
+        >
+      ).mockResolvedValue(mockResponse);
+
+      const result = await repository.getProjects();
+
+      expect(result).toEqual(mockProjects);
+      expect(mockHttpClient.sendRequest).toHaveBeenCalledWith({
+        endpoint: "project/search",
+        method: "GET",
+        queryParams: {},
+      });
+    });
+
+    test("should handle empty paginated response", async () => {
+      const mockResponse = createMockProjectSearchResponse([]);
+
+      (
+        mockHttpClient.sendRequest as Mock<
+          (options: HttpRequestOptions) => Promise<ProjectSearchResponse>
+        >
+      ).mockResolvedValue(mockResponse);
+
+      const result = await repository.getProjects();
+
+      expect(result).toEqual([]);
+      expect(result.length).toBe(0);
+    });
+
+    test("should pass query parameters correctly", async () => {
+      const mockProjects = [createMockProject()];
+      const mockResponse = createMockProjectSearchResponse(mockProjects);
+
+      (
+        mockHttpClient.sendRequest as Mock<
+          (options: HttpRequestOptions) => Promise<ProjectSearchResponse>
+        >
+      ).mockResolvedValue(mockResponse);
+
+      await repository.getProjects({
+        maxResults: 10,
+        startAt: 5,
+        searchQuery: "test",
+        typeKey: "software",
+      });
+
+      expect(mockHttpClient.sendRequest).toHaveBeenCalledWith({
+        endpoint: "project/search",
+        method: "GET",
+        queryParams: {
+          maxResults: 10,
+          startAt: 5,
+          query: "test",
+          typeKey: "software",
+        },
+      });
+    });
+  });
+
+  describe("searchProjects", () => {
+    test("should extract projects from paginated search response", async () => {
+      const mockProjects = [
+        createMockProject({ key: "SEARCH1", name: "Search Result 1" }),
+      ];
+
+      const mockResponse = createMockProjectSearchResponse(mockProjects);
+
+      (
+        mockHttpClient.sendRequest as Mock<
+          (options: HttpRequestOptions) => Promise<ProjectSearchResponse>
+        >
+      ).mockResolvedValue(mockResponse);
+
+      const result = await repository.searchProjects("test query");
+
+      expect(result).toEqual(mockProjects);
+      expect(mockHttpClient.sendRequest).toHaveBeenCalledWith({
+        endpoint: "project/search",
+        method: "GET",
+        queryParams: {
+          query: "test query",
+          maxResults: 50,
+        },
+      });
+    });
+
+    test("should handle custom maxResults in search", async () => {
+      const mockResponse = createMockProjectSearchResponse([]);
+
+      (
+        mockHttpClient.sendRequest as Mock<
+          (options: HttpRequestOptions) => Promise<ProjectSearchResponse>
+        >
+      ).mockResolvedValue(mockResponse);
+
+      await repository.searchProjects("test", 25);
+
+      expect(mockHttpClient.sendRequest).toHaveBeenCalledWith({
+        endpoint: "project/search",
+        method: "GET",
+        queryParams: {
+          query: "test",
+          maxResults: 25,
+        },
+      });
+    });
+  });
+
+  describe("pagination handling", () => {
+    test("should handle large paginated response", async () => {
+      const mockProjects = Array(100)
+        .fill(null)
+        .map((_, i) =>
+          createMockProject({ key: `PROJ${i}`, name: `Project ${i}` }),
+        );
+
+      const mockResponse = createMockProjectSearchResponse(mockProjects, {
+        startAt: 0,
+        maxResults: 100,
+        total: 250,
+        isLast: false,
+      });
+
+      (
+        mockHttpClient.sendRequest as Mock<
+          (options: HttpRequestOptions) => Promise<ProjectSearchResponse>
+        >
+      ).mockResolvedValue(mockResponse);
+
+      const result = await repository.getProjects({ maxResults: 100 });
+
+      expect(result).toEqual(mockProjects);
+      expect(result.length).toBe(100);
+    });
+
+    test("should handle last page of paginated response", async () => {
+      const mockProjects = [
+        createMockProject({ key: "LAST1", name: "Last Project 1" }),
+        createMockProject({ key: "LAST2", name: "Last Project 2" }),
+      ];
+
+      const mockResponse = createMockProjectSearchResponse(mockProjects, {
+        startAt: 98,
+        maxResults: 50,
+        total: 100,
+        isLast: true,
+      });
+
+      (
+        mockHttpClient.sendRequest as Mock<
+          (options: HttpRequestOptions) => Promise<ProjectSearchResponse>
+        >
+      ).mockResolvedValue(mockResponse);
+
+      const result = await repository.getProjects({
+        startAt: 98,
+        maxResults: 50,
+      });
+
+      expect(result).toEqual(mockProjects);
+      expect(result.length).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
 - Fix pagination handling in ProjectRepository to extract values from paginated responses 
 - Resolves jira_get_projects and search functionality issues